### PR TITLE
Configuração de caminhos das imagens de QRCode e rubrica

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -4,3 +4,5 @@ SECRET=younIrtyij3
 SERVIDOR_OAUTH=cas.staging.iti.br/oauth2.0
 ASSINATURA_API_URI=https://assinatura-api.staging.iti.br/externo/v2/
 SERVER_PORT=8080
+IMG_RUBRIC_SOURCE=./assets/rubrica.png
+IMG_QR_CODE_SOURCE=./assets/qrcode-HML.svg

--- a/src/main/java/com/esp/govbrsignatureintegration/GovbrSignatureIntegrationApplication.java
+++ b/src/main/java/com/esp/govbrsignatureintegration/GovbrSignatureIntegrationApplication.java
@@ -24,6 +24,12 @@ public class GovbrSignatureIntegrationApplication {
     @Value("${govbr.secret}")
     private String secret;
 
+    @Value("${govbr.imgRubricSource}")
+    private String imgRubricSource;
+
+    @Value("${govbr.imgQRCodeSource}")
+    private String imgQRCodeSource;
+
     @GetMapping("/")
     public String index(@RequestParam(name = "code", required = false) String code) {
         if (code == null) {

--- a/src/main/java/com/esp/govbrsignatureintegration/GovbrSignatureIntegrationApplication.java
+++ b/src/main/java/com/esp/govbrsignatureintegration/GovbrSignatureIntegrationApplication.java
@@ -24,12 +24,6 @@ public class GovbrSignatureIntegrationApplication {
     @Value("${govbr.secret}")
     private String secret;
 
-    @Value("${govbr.imgRubricSource}")
-    private String imgRubricSource;
-
-    @Value("${govbr.imgQRCodeSource}")
-    private String imgQRCodeSource;
-
     @GetMapping("/")
     public String index(@RequestParam(name = "code", required = false) String code) {
         if (code == null) {

--- a/src/main/java/com/esp/govbrsignatureintegration/configs/GlobalCorsConfiguration.java
+++ b/src/main/java/com/esp/govbrsignatureintegration/configs/GlobalCorsConfiguration.java
@@ -1,0 +1,21 @@
+package com.esp.govbrsignatureintegration.configs;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class GlobalCorsConfiguration implements WebMvcConfigurer {
+
+    @Value("${govbr.redirectUri}")
+    private String redirectUri;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedMethods("GET", "POST").allowedOrigins(redirectUri);
+    }
+}

--- a/src/main/java/com/esp/govbrsignatureintegration/resources/SignPdfResource.java
+++ b/src/main/java/com/esp/govbrsignatureintegration/resources/SignPdfResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +31,12 @@ public class SignPdfResource {
     @Autowired
     private AssinarPKCS7Service assinarPKCS7Service;
 
+    @Value("${govbr.imgRubricSource}")
+    private String imgRubricSource;
+
+    @Value("${govbr.imgQRCodeSource}")
+    private String imgQRCodeSource;
+
     /**
      * Rota para assinar um documento PDF.
      *
@@ -43,7 +50,7 @@ public class SignPdfResource {
 
         String token = this.getTokenService.getToken(code);
 
-        SignatureManager signatureManager = new SignatureManager(token, this.assinarPKCS7Service);
+        SignatureManager signatureManager = new SignatureManager(token, this.assinarPKCS7Service, this.imgRubricSource, this.imgQRCodeSource);
 
         byte[] outputBytes = signatureManager.getBytesPdfSigned(pdf.getInputStream());
 
@@ -67,7 +74,7 @@ public class SignPdfResource {
 
         String token = this.getTokenService.getToken(code);
 
-        SignatureManager signatureManager = new SignatureManager(token, this.assinarPKCS7Service);
+        SignatureManager signatureManager = new SignatureManager(token, this.assinarPKCS7Service, this.imgRubricSource, this.imgQRCodeSource);
 
         for (MultipartFile pdf : pdfs) {
             byte[] outputBytes = signatureManager.getBytesPdfSigned(pdf.getInputStream());

--- a/src/main/java/com/esp/govbrsignatureintegration/resources/SignPdfResource.java
+++ b/src/main/java/com/esp/govbrsignatureintegration/resources/SignPdfResource.java
@@ -20,7 +20,7 @@ import java.util.zip.ZipOutputStream;
 
 @Slf4j
 @RestController
-@CrossOrigin(origins = "*")
+//@CrossOrigin(origins = "*")
 @RequestMapping("/signPdf")
 public class SignPdfResource {
     private static final Logger logger = LoggerFactory.getLogger(SignPdfResource.class);

--- a/src/main/java/com/esp/govbrsignatureintegration/signature/SignatureManager.java
+++ b/src/main/java/com/esp/govbrsignatureintegration/signature/SignatureManager.java
@@ -24,13 +24,19 @@ import java.util.Calendar;
 public class SignatureManager {
     private static final Logger logger = LoggerFactory.getLogger(SignatureManager.class);
 
+    private String imgRubricSource;
+
+    private String imgQRCodeSource;
+
     private static final int ESTIMATED_SIZE = 8192; // Tamanho estimado da assinatura.
     private String token; // token para assinar o documento
     private AssinarPKCS7Service assinarPKCS7Service; // webcliente para fazer a request
 
-    public SignatureManager(String token, AssinarPKCS7Service assinarPKCS7Service) {
+    public SignatureManager(String token, AssinarPKCS7Service assinarPKCS7Service, String imgRubricSource, String imgQRCodeSource) {
         this.token = token;
         this.assinarPKCS7Service = assinarPKCS7Service;
+        this.imgRubricSource = imgRubricSource;
+        this.imgQRCodeSource = imgQRCodeSource;
     }
 
     // Usado para gerar os bytes de um arquivo assinado
@@ -78,7 +84,7 @@ public class SignatureManager {
         float pageHeight = pageDimensions.getHeight();
 
         // Adiciona imagem QRcode
-        Image imgQRcode = SvgConverter.convertToImage(new FileInputStream("./assets/qrcode-HML.svg"), pdfDoc).setFixedPosition(1, pageWidth - 150f, pageHeight - 200f);
+        Image imgQRcode = SvgConverter.convertToImage(new FileInputStream(this.imgQRCodeSource), pdfDoc).setFixedPosition(1, pageWidth - 150f, pageHeight - 200f);
 
         document.add(imgQRcode);
         document.close();
@@ -119,7 +125,7 @@ public class SignatureManager {
                 .setReason("ESP - Escola de Saúde Pública do Ceará") // Razão
                 .setLocation("Fortaleza - CE") // localização
                 .setSignatureCreator("govbr-signature-integration") // nome da aplicação
-                .setSignatureGraphic(ImageDataFactory.create("./assets/rubrica.png")) // Imagem lateral da assinatura
+                .setSignatureGraphic(ImageDataFactory.create(this.imgRubricSource)) // Imagem lateral da assinatura
                 .setPageRect(rectangle).setPageNumber(1);
 
         logger.info("buildAppearence | init");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,5 @@ govbr:
   secret: ${SECRET}
   servidorOauth: ${SERVIDOR_OAUTH}
   assinaturaApiUri: ${ASSINATURA_API_URI}
+  imgRubricSource: ${IMG_RUBRIC_SOURCE}
+  imgQRCodeSource: ${IMG_QR_CODE_SOURCE}


### PR DESCRIPTION
## Contexto

No momento da criação do certificado, uma imagem que contem o QRCode para validação e outra que com uma rubrica que fica no quadro que contem as informações da assinatura digital precisam ser adicionadas. Para tanto, precisamos que cada uma dessas imagens sejam ou possam ser diferentes em cada ambiente (homologação e produção).

Esse PR trata da configuração que fizemos pra que possamos adicionar nas variáveis de ambiente os caminhos para os arquivos de acordo com o ambiente em que a aplicação vai estar ativa.

## Solução

Foram adicionadas mais duas vaiáveis de ambiente no arquivo `.env` e `.env.exemple`:

- IMG_RUBRIC_SOURCE: caminho para a imagem da rubrica
- IMG_QR_CODE_SOURCE: caminho para a imagem do QRCode

## OBS

> Também foi ajustado aqui nesse PR a configuração global para a CORS Policy.